### PR TITLE
Add sample manifests

### DIFF
--- a/deploy/deployment.yaml
+++ b/deploy/deployment.yaml
@@ -1,0 +1,24 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kube-summary-exporter
+  namespace: monitoring
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: kube-summary-exporter
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: kube-summary-exporter
+    spec:
+      serviceAccountName: kube-summary-exporter
+      securityContext:
+        runAsUser: 65532
+        runAsGroup: 65532
+      containers:
+      - name: kube-summary-exporter
+        image: quay.io/utilitywarehouse/kube-summary-exporter
+        livenessProbe:
+          httpGet:
+            port: 9779

--- a/deploy/rbac.yaml
+++ b/deploy/rbac.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kube-summary-exporter
+  namespace: monitoring
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kube-summary-exporter
+rules:
+- apiGroups: [""]
+  resources: ["nodes/proxy"]
+  verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kube-summary-exporter
+subjects:
+- kind: ServiceAccount
+  name: kube-summary-exporter
+  namespace: monitoring
+roleRef:
+  kind: ClusterRole
+  name: kube-summary-exporter
+  apiGroup: rbac.authorization.k8s.io

--- a/deploy/service.yaml
+++ b/deploy/service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: kube-summary-exporter
+  namespace: monitoring
+spec:
+  selector:
+    app.kubernetes.io/name: kube-summary-exporter
+  ports:
+  - name: http
+    port: 9779
+    targetPort: 9779


### PR DESCRIPTION
This PR adds sample manifest files. These make it easy for users to start using kube-summary-exporter.

ref #3 